### PR TITLE
Add initialization of the member_names array in the replace_names method...

### DIFF
--- a/ee2/thirdparty/vz_members/ft.vz_members.php
+++ b/ee2/thirdparty/vz_members/ft.vz_members.php
@@ -412,6 +412,9 @@ class Vz_members_ft extends EE_Fieldtype {
         // Get the member info
         $members = $this->_get_member_names($field_data, $params['orderby'], $params['sort']);
         
+        // Initialize the member_names array
+        $member_nammes = array();
+        
         // Put the names in an array
         foreach ($members as $member)
         {


### PR DESCRIPTION
..., as an error was being caused if no members were found.
